### PR TITLE
Delete submit.js; use Netlify _redirects

### DIFF
--- a/src/pages/submit.js
+++ b/src/pages/submit.js
@@ -1,9 +1,0 @@
-import React from 'react'
-
-if (typeof window !== `undefined`) window.location.replace(`https://airtable.com/shraBPEf6TXdRZbUU`)
-
-const IndexPage = () => {
-    return <></>
-}
-
-export default IndexPage

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,2 @@
+# Redirects powered by Netlify
+/submit              https://airtable.com/shraBPEf6TXdRZbUU


### PR DESCRIPTION
With `redirects.js`, any page on `localhost:8000` on a local development server would get redirected, rather than just `/submit`. I'm trying Netlify's `_redirects` file instead.