### PR TITLE
Show random featured stories

### DIFF
--- a/src/components/FeaturedStories.js
+++ b/src/components/FeaturedStories.js
@@ -1,58 +1,65 @@
 import Gallery from "./Gallery"
 import StoryCard from "../components/StoryCard"
-import { StaticQuery, graphql } from "gatsby"
-import React from "react"
+import { useStaticQuery, graphql } from "gatsby"
+import React, { useState, useEffect } from "react"
 
-const FeaturedStories = props => (
-  <StaticQuery
-    query={graphql`
-      {
-        allAirtable(
-          filter: { data: { Featured: { eq: true } } }
-          sort: { order: DESC, fields: id }
-        ) {
-          edges {
-            node {
-              id
-              data {
-                Author
-                Status
-                Story_Name
-                Photo {
-                  thumbnails {
-                    large {
-                      url
-                    }
+const FeaturedStories = ({ nCols, nStories }) => {
+  const data = useStaticQuery(graphql`
+    {
+      allAirtable(
+        filter: { data: { Featured: { eq: true } } }
+        sort: { order: DESC, fields: id }
+      ) {
+        edges {
+          node {
+            id
+            data {
+              Author
+              Status
+              Story_Name
+              Photo {
+                thumbnails {
+                  large {
+                    url
                   }
                 }
-                Audio {
-                  url
-                }
-                School
-                Tags
-                Grade
               }
+              Audio {
+                url
+              }
+              School
+              Tags
+              Grade
             }
           }
         }
       }
-    `}
-    render={data => {
-      return (
-        <Gallery n={props.nCols}>
-          {data.allAirtable.edges.slice(0, 6).map(story => (
-            <StoryCard
-              key={story.node.id}
-              title={story.node.data.Story_Name}
-              photoUrl={story.node.data.Photo[0].thumbnails.large.url}
-              author={story.node.data.Author}
-              audio={story.node.data.Audio ? story.node.data.Audio[0].url : ""}
-            />
-          ))}
-        </Gallery>
-      )
-    }}
-  />
-)
+    }
+  `)
+
+  const [stories, updateStories] = useState([])
+
+  useEffect(() => {
+    const stories = data.allAirtable.edges
+    const randomN = stories
+      .sort(() => Math.random() - Math.random())
+      .slice(0, nStories)
+    updateStories(randomN)
+  }, [])
+
+  return (
+    <Gallery n={nCols}>
+      {stories.map(story => (
+        <StoryCard
+          key={story.node.id}
+          title={story.node.data.Story_Name}
+          photoUrl={story.node.data.Photo[0].thumbnails.large.url}
+          author={story.node.data.Author}
+          audio={story.node.data.Audio ? story.node.data.Audio[0].url : ""}
+        />
+      ))}
+    </Gallery>
+  )
+}
 
 export default FeaturedStories


### PR DESCRIPTION
We want to show six random featured stories on the homepage. Previously I couldn't get it to work so I just showed the first six in the data returned. I cleaned up `FeaturedStories.js` component and made it work.

- Deconstructed props
- Switched from `StaticQuery` component to `useStaticQuery` hook
- Used `useState` and `useEffect` to select `nStories` stories randomly, just once, on the client-side and render them

Definitely more re-factoring to do in the future, e.g. probably getting rid of `nCols` or otherwise separating out that concern, making the `StoryCard` props more manageable.

Resolves #15 