### PR TITLE
Refactor cohort as document type

### DIFF
--- a/studio/schemas/documents/cohort.js
+++ b/studio/schemas/documents/cohort.js
@@ -1,0 +1,17 @@
+export default {
+  name: "cohort",
+  title: "Cohorts",
+  type: "document",
+  fields: [
+    {
+      name: "title",
+      title: "Title",
+      type: "string",
+      description: 'e.g. "Cohort 9 (2027-2028)"',
+      validation: (Rule) => Rule.required(),
+    },
+  ],
+  preview: {
+    select: { title: "title" },
+  },
+};

--- a/studio/schemas/documents/teacher.js
+++ b/studio/schemas/documents/teacher.js
@@ -30,19 +30,8 @@ export default {
     {
       name: "cohort",
       title: "Cohort",
-      type: "string",
-      options: {
-        list: [
-          "Cohort 1 (2019-2020)",
-          "Cohort 2 (2020-2021)",
-          "Cohort 3 (2021-2022)",
-          "Cohort 4 (2022-2023)",
-          "Cohort 5 (2023-2024)",
-          "Cohort 6 (2024-2025)",
-          "Cohort 7 (2025-2026)",
-          "Cohort 8 (2026-2027)",
-        ],
-      },
+      type: "reference",
+      to: [{ type: "cohort" }],
       validation: (Rule) => Rule.required(),
     },
   ],

--- a/studio/schemas/schema.js
+++ b/studio/schemas/schema.js
@@ -5,6 +5,7 @@ import guide from "./documents/guide";
 import teamMember from "./documents/teamMember";
 import story from "./documents/story";
 import school from "./documents/school";
+import cohort from "./documents/cohort";
 import teacher from "./documents/teacher";
 import book from "./documents/book";
 import newsItem from "./documents/newsItem";
@@ -32,6 +33,7 @@ export default [
   teamMember,
   story,
   school,
+  cohort,
   teacher,
   book,
   newsItem,

--- a/web/src/pages/teachers.js
+++ b/web/src/pages/teachers.js
@@ -58,7 +58,7 @@ export const pageQuery = graphql`
       distinct(field: location)
     }
     allSanityTeacher {
-      group(field: cohort) {
+      group(field: cohort___title) {
         fieldValue
         nodes {
           name


### PR DESCRIPTION
Admins can now add new cohorts directly in Sanity Studio without requiring a code change each year.