### PR TITLE
Fix Netlify Gatsby build on modern Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "lerna run dev --parallel",
     "format": "lerna run format",
     "build-studio": "lerna bootstrap && cd studio && npm run build",
-    "build-web": "lerna bootstrap && (cd studio && SANITY_AUTH_TOKEN=$SANITY_DEPLOY_STUDIO_TOKEN npm run graphql-deploy) && (cd web && npm run build)",
+    "build-web": "lerna bootstrap && (cd studio && SANITY_AUTH_TOKEN=$SANITY_DEPLOY_STUDIO_TOKEN npm run graphql-deploy) && (cd web && NODE_OPTIONS=--openssl-legacy-provider npm run build)",
     "graphql-deploy": "lerna run graphql-deploy",
     "lint": "lerna run lint",
     "postinstall": "lerna bootstrap",


### PR DESCRIPTION
## Summary
- Adds `NODE_OPTIONS=--openssl-legacy-provider` to the Gatsby site build step in the root `build-web` script.
- Leaves the Sanity GraphQL deploy step unchanged.

## Bug
Production Netlify deploy `6a249856d27d8af5964706c9` on `main` failed during the Gatsby site build after Netlify selected Node.js `v24.16.0`.

The Sanity GraphQL deploy completed successfully, then `gatsby build` failed with:

```text
Error: error:0308010C:digital envelope routines::unsupported
code: 'ERR_OSSL_EVP_UNSUPPORTED'
```

This is the older Gatsby 3 / Webpack build stack hitting newer Node/OpenSSL defaults.

## Reproduction
From the repo root on a modern Node runtime:

```bash
npm --prefix web run build -- --no-color
```

That reproduces the Webpack/OpenSSL crash locally.

## Fix
Run only the Gatsby site build with the legacy OpenSSL provider:

```bash
NODE_OPTIONS=--openssl-legacy-provider npm --prefix web run build -- --no-color
```

The root `build-web` command now applies that flag inside the `web` step only:

```bash
(cd web && NODE_OPTIONS=--openssl-legacy-provider npm run build)
```

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"`
- `NODE_OPTIONS=--openssl-legacy-provider npm --prefix web run build -- --no-color`

The local Gatsby build completed successfully and generated 1,335 static pages.

## Follow-up
This should be treated as a production unblocker. The longer-term fix is to upgrade Gatsby/Webpack and related dependencies so the legacy OpenSSL provider is no longer needed.
