### PR TITLE
Add validation to require tags to be non-empty

### DIFF
--- a/studio/schemas/documents/story.ts
+++ b/studio/schemas/documents/story.ts
@@ -74,8 +74,17 @@ export default {
               "Violence",
             ],
           },
+          validation: (Rule) => Rule.required().min(1),
         },
       ],
+      validation: (Rule) =>
+        Rule.custom((tags) => {
+          if (!tags) return true;
+          if (tags.some((tag) => tag === "")) {
+            return "Tags cannot be empty strings";
+          }
+          return true;
+        }),
     },
     {
       name: "secondLanguageAudio",


### PR DESCRIPTION
## Summary

Added validation to the `tags` field in the story schema to prevent empty-string tags from being created in Sanity Studio.

## Changes

- Added `.required().min(1)` validation to each tag string to ensure it's not empty
- Added array-level custom validation to catch any empty-string tags with a clear error message
- Prevents `/tag/` routes with empty strings from being created

This prevents future empty-string tags, but does not clean up the 28 existing stories with empty tags. Those can be cleaned up with a separate data migration if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)