### PR TITLE
Fix Gatsby prod build cache

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,6 +4,7 @@
   "description": "The We Are America Project is working with teachers and young people across the country to spark a national conversation about American identity, led by the next generation.",
   "version": "0.1.0",
   "scripts": {
+    "prebuild": "gatsby clean",
     "build": "gatsby build",
     "dev": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",


### PR DESCRIPTION
## Summary
- Run `gatsby clean` automatically before web production builds
- Prevent stale Gatsby cache/page-query artifacts from breaking Netlify page-data generation

## Verification
- `npm --prefix web run build`

## Notes
The failed Netlify build could not find a temporary query result while writing `page-data.json` for `/story/growing-through-her-r/`. A clean Gatsby cache reproduced a successful build locally, so this keeps Netlify builds fresh before `gatsby build`.

This branch is based on `feat/optimize-images-gatsby-plugin`; the cache fix itself is commit `270997b`.