### PR TITLE
Add canonical story slug migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,28 @@ npm test
 npm --prefix web run test:update
 ```
 
+### Story URL migration
+
+Story pages use the hidden Sanity `story.slug` field when it is present. The
+canonical format is `/story/{year}/{title-slug}/`, where `year` falls back to
+the story document creation year during migration.
+
+Preview the proposed Sanity slug updates and legacy redirects:
+
+```
+npm run story-slugs:audit
+```
+
+Apply the slug backfill after reviewing the audit output:
+
+```
+SANITY_WRITE_TOKEN=... npm run story-slugs:write
+```
+
+The audit also prints safe redirects to copy into `web/static/_redirects`.
+Use `npm run story-slugs:audit -- --redirects` to print the full redirect list.
+Ambiguous legacy redirects are skipped and listed separately.
+
 ## Deploy Sanity GraphQL API
 
 ```

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "graphql-deploy": "lerna run graphql-deploy",
     "lint": "lerna run lint",
     "postinstall": "lerna bootstrap",
+    "story-slugs:audit": "node scripts/generate-story-slugs.js",
+    "story-slugs:write": "node scripts/generate-story-slugs.js --write",
     "test": "npm --prefix web test"
   },
   "devDependencies": {

--- a/scripts/generate-story-slugs.js
+++ b/scripts/generate-story-slugs.js
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+
+const API_VERSION = "2023-08-01";
+const DEFAULT_PROJECT_ID = "nr9digz2";
+const DEFAULT_DATASET = "production";
+
+const args = new Set(process.argv.slice(2));
+const shouldWrite = args.has("--write");
+const isVerbose = args.has("--verbose");
+const shouldPrintRedirects = args.has("--redirects") || isVerbose;
+const projectId = process.env.SANITY_PROJECT_ID || DEFAULT_PROJECT_ID;
+const dataset = process.env.SANITY_DATASET || DEFAULT_DATASET;
+const token = process.env.SANITY_WRITE_TOKEN || process.env.SANITY_AUTH_TOKEN;
+
+function slugify(string) {
+  const a =
+    "àáâäæãåāăąçćčđďèéêëēėęěğǵḧîïíīįìłḿñńǹňôöòóœøōõṕŕřßśšşșťțûüùúūǘůűųẃẍÿýžźż·/_,:;";
+  const b =
+    "aaaaaaaaaacccddeeeeeeeegghiiiiiilmnnnnooooooooprrsssssttuuuuuuuuuwxyyzzz------";
+  const p = new RegExp(a.split("").join("|"), "g");
+
+  return string
+    .toString()
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(p, c => b.charAt(a.indexOf(c)))
+    .replace(/&/g, "-and-")
+    .replace(/[^\w-]+/g, "")
+    .replace(/--+/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "");
+}
+
+function getLegacyStorySlug(storyTitle, authorFirstName) {
+  const truncatedStoryTitle = storyTitle
+    .split(" ")
+    .slice(0, 4)
+    .join(" ");
+  const firstLetterOfName = authorFirstName[0];
+  return slugify(`${truncatedStoryTitle}-${firstLetterOfName}`);
+}
+
+function normalizeStorySlug(slug) {
+  return slug.replace(/^\/+/, "").replace(/^story\//, "").replace(/\/+$/, "");
+}
+
+function storyYear(story) {
+  return new Date(story._createdAt).getUTCFullYear();
+}
+
+function baseSlug(story) {
+  const titleSlug = slugify(story.storyTitle) || "untitled-story";
+  return `${storyYear(story)}/${titleSlug}`;
+}
+
+async function sanityQuery(query) {
+  const url = new URL(
+    `https://${projectId}.api.sanity.io/v${API_VERSION}/data/query/${dataset}`
+  );
+  url.searchParams.set("query", query);
+
+  const response = await fetch(url);
+  const data = await response.json();
+
+  if (!response.ok || data.error) {
+    throw new Error(
+      `Sanity query failed: ${data.error?.description || response.statusText}`
+    );
+  }
+
+  return data.result;
+}
+
+async function sanityMutate(mutations) {
+  if (!token) {
+    throw new Error(
+      "Missing SANITY_WRITE_TOKEN or SANITY_AUTH_TOKEN for --write."
+    );
+  }
+
+  const response = await fetch(
+    `https://${projectId}.api.sanity.io/v${API_VERSION}/data/mutate/${dataset}`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ mutations })
+    }
+  );
+  const data = await response.json();
+
+  if (!response.ok || data.error) {
+    throw new Error(
+      `Sanity mutation failed: ${data.error?.description || response.statusText}`
+    );
+  }
+
+  return data;
+}
+
+function assignCanonicalSlugs(stories) {
+  const groups = new Map();
+
+  for (const story of stories) {
+    const base = baseSlug(story);
+    groups.set(base, [...(groups.get(base) || []), story]);
+  }
+
+  const assignments = [];
+
+  for (const [base, group] of groups) {
+    const sorted = group.sort((a, b) => {
+      if (a._createdAt === b._createdAt) {
+        return a._id.localeCompare(b._id);
+      }
+      return a._createdAt.localeCompare(b._createdAt);
+    });
+
+    sorted.forEach((story, index) => {
+      assignments.push({
+        ...story,
+        canonicalSlug: index === 0 ? base : `${base}-${index + 1}`,
+        hadCanonicalCollision: sorted.length > 1
+      });
+    });
+  }
+
+  return assignments.sort((a, b) => a.canonicalSlug.localeCompare(b.canonicalSlug));
+}
+
+function getRedirects(assignments) {
+  const legacyGroups = new Map();
+
+  for (const story of assignments) {
+    const legacyPath = `/story/${getLegacyStorySlug(
+      story.storyTitle,
+      story.authorFirstName
+    )}/`;
+    legacyGroups.set(legacyPath, [...(legacyGroups.get(legacyPath) || []), story]);
+  }
+
+  const redirects = [];
+  const ambiguous = [];
+
+  for (const [legacyPath, stories] of legacyGroups) {
+    if (stories.length > 1) {
+      ambiguous.push({ legacyPath, stories });
+      continue;
+    }
+
+    const story = stories[0];
+    const canonicalPath = `/story/${story.canonicalSlug}/`;
+
+    if (legacyPath !== canonicalPath) {
+      redirects.push(`${legacyPath}  ${canonicalPath}  301!`);
+    }
+  }
+
+  return { redirects: redirects.sort(), ambiguous };
+}
+
+function printReport(assignments) {
+  const changes = assignments.filter(
+    story => normalizeStorySlug(story.slug || "") !== story.canonicalSlug
+  );
+  const collisions = assignments.filter(story => story.hadCanonicalCollision);
+  const { redirects, ambiguous } = getRedirects(assignments);
+
+  console.log(`Project: ${projectId}`);
+  console.log(`Dataset: ${dataset}`);
+  console.log(`Stories: ${assignments.length}`);
+  console.log(`Slug updates needed: ${changes.length}`);
+  console.log(`Canonical collisions needing suffixes: ${collisions.length}`);
+  console.log(`Safe legacy redirects: ${redirects.length}`);
+  console.log(`Ambiguous legacy redirects skipped: ${ambiguous.length}`);
+
+  if (collisions.length) {
+    console.log("\nCanonical collision suffixes:");
+    for (const story of collisions) {
+      console.log(
+        `- ${story.canonicalSlug}: ${story.storyTitle} (${story.authorFirstName}, ${story._id})`
+      );
+    }
+  }
+
+  if (changes.length) {
+    const visibleChanges = isVerbose ? changes : changes.slice(0, 25);
+    console.log("\nSlug updates:");
+    for (const story of visibleChanges) {
+      console.log(
+        `- ${story._id}: ${story.slug || "(empty)"} -> ${story.canonicalSlug}`
+      );
+    }
+    if (!isVerbose && changes.length > visibleChanges.length) {
+      console.log(
+        `...and ${changes.length - visibleChanges.length} more. Re-run with --verbose to show every update.`
+      );
+    }
+  }
+
+  if (redirects.length && shouldPrintRedirects) {
+    console.log("\nRedirects to add to web/static/_redirects:");
+    console.log(redirects.join("\n"));
+  } else if (redirects.length) {
+    console.log(
+      "\nRe-run with --redirects to print safe redirects for web/static/_redirects."
+    );
+  }
+
+  if (ambiguous.length) {
+    console.log("\nAmbiguous legacy redirects skipped:");
+    for (const { legacyPath, stories } of ambiguous) {
+      console.log(`- ${legacyPath}`);
+      for (const story of stories) {
+        console.log(`  - /story/${story.canonicalSlug}/ (${story._id})`);
+      }
+    }
+  }
+}
+
+async function main() {
+  const stories = await sanityQuery(`*[
+    _type == "story" &&
+    isHidden != true &&
+    defined(storyTitle) &&
+    defined(authorFirstName) &&
+    defined(_createdAt)
+  ] | order(_createdAt asc, _id asc) {
+    _id,
+    _createdAt,
+    authorFirstName,
+    storyTitle,
+    slug
+  }`);
+
+  const assignments = assignCanonicalSlugs(stories);
+  printReport(assignments);
+
+  if (!shouldWrite) {
+    console.log("\nDry run only. Re-run with --write to patch Sanity slugs.");
+    return;
+  }
+
+  const mutations = assignments
+    .filter(story => normalizeStorySlug(story.slug || "") !== story.canonicalSlug)
+    .map(story => ({
+      patch: {
+        id: story._id,
+        set: {
+          slug: story.canonicalSlug
+        }
+      }
+    }));
+
+  if (!mutations.length) {
+    console.log("\nNo Sanity slug updates needed.");
+    return;
+  }
+
+  await sanityMutate(mutations);
+  console.log(`\nPatched ${mutations.length} Sanity story slugs.`);
+}
+
+main().catch(error => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/studio/schemas/documents/story.ts
+++ b/studio/schemas/documents/story.ts
@@ -147,8 +147,17 @@ export default {
     {
       name: "slug",
       title: "Slug",
+      description:
+        'Canonical website path after /story/, e.g. "2024/growing-through-her".',
       type: "string",
       hidden: true, // Hide in Sanity Studio.
+      validation: (Rule) =>
+        Rule.custom((slug) => {
+          if (!slug) return true;
+          return /^\d{4}\/[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)
+            ? true
+            : 'Slug must look like "2024/story-title".';
+        }),
     },
   ],
 };

--- a/web/gatsby-node.js
+++ b/web/gatsby-node.js
@@ -17,7 +17,7 @@ function slugify(string) {
     .replace(/-+$/, "");
 }
 
-function getStorySlug(storyTitle, authorFirstName) {
+function getLegacyStorySlug(storyTitle, authorFirstName) {
   const truncatedStoryTitle = storyTitle
     .split(" ")
     .slice(0, 4)
@@ -26,12 +26,24 @@ function getStorySlug(storyTitle, authorFirstName) {
   return slugify(`${truncatedStoryTitle}-${firstLetterOfName}`);
 }
 
+function normalizeStorySlug(slug) {
+  return slug.replace(/^\/+/, "").replace(/^story\//, "").replace(/\/+$/, "");
+}
+
+function getStoryPath({ slug, storyTitle, authorFirstName }) {
+  const storySlug = slug
+    ? normalizeStorySlug(slug)
+    : getLegacyStorySlug(storyTitle, authorFirstName);
+
+  return `/story/${storySlug}/`;
+}
+
 function getTagSlug(tag) {
   return slugify(tag);
 }
 
 exports.createPages = async ({ graphql, actions }) => {
-  const { createPage } = actions;
+  const { createPage, createRedirect } = actions;
 
   const storiesResult = await graphql(`
     query storiesQuery {
@@ -40,6 +52,7 @@ exports.createPages = async ({ graphql, actions }) => {
           id
           authorFirstName
           storyTitle
+          slug
           photo {
             asset {
               id
@@ -86,6 +99,7 @@ exports.createPages = async ({ graphql, actions }) => {
           nodes {
             authorFirstName
             storyTitle
+            slug
             photo {
               asset {
                 id
@@ -112,6 +126,7 @@ exports.createPages = async ({ graphql, actions }) => {
           nodes {
             authorFirstName
             storyTitle
+            slug
             photo {
               asset {
                 id
@@ -138,6 +153,7 @@ exports.createPages = async ({ graphql, actions }) => {
           nodes {
             authorFirstName
             storyTitle
+            slug
             photo {
               asset {
                 id
@@ -173,15 +189,41 @@ exports.createPages = async ({ graphql, actions }) => {
     });
   }
 
+  const storyPaths = new Map();
+
   storiesResult.data.allSanityStory.nodes.forEach(node => {
-    const slug = getStorySlug(node.storyTitle, node.authorFirstName);
+    const path = getStoryPath(node);
+    const existing = storyPaths.get(path);
+    if (existing && (existing.slug || node.slug)) {
+      throw new Error(
+        `Duplicate story path "${path}" for "${existing.storyTitle}" (${existing.id}) and "${node.storyTitle}" (${node.id}). Set unique story.slug values in Sanity.`
+      );
+    }
+    storyPaths.set(path, node);
+
     createPage({
-      path: `/story/${slug}/`,
+      path,
       component: require.resolve("./src/templates/story.tsx"),
       context: {
         data: node
       }
     });
+
+    if (node.slug) {
+      const legacyPath = getStoryPath({
+        storyTitle: node.storyTitle,
+        authorFirstName: node.authorFirstName
+      });
+
+      if (legacyPath !== path) {
+        createRedirect({
+          fromPath: legacyPath,
+          toPath: path,
+          isPermanent: true,
+          redirectInBrowser: true
+        });
+      }
+    }
   });
 
   const createTagPage = tagType => ({ fieldValue: tag, nodes }) => {

--- a/web/src/components/FeaturedStories.tsx
+++ b/web/src/components/FeaturedStories.tsx
@@ -23,6 +23,7 @@ const FeaturedStories = ({ nCols, nStories }) => {
           id
           authorFirstName
           storyTitle
+          slug
           photo {
             asset {
               id
@@ -58,6 +59,7 @@ const FeaturedStories = ({ nCols, nStories }) => {
           title={story.storyTitle}
           photo={story.photo}
           author={story.authorFirstName}
+          slug={story.slug}
         />
       ))}
     </Gallery>

--- a/web/src/components/PersonCard.tsx
+++ b/web/src/components/PersonCard.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import { Link } from "gatsby";
 import { GatsbyImage, getImage } from "gatsby-plugin-image";
 import { PortableText } from "@portabletext/react";
-import { getStorySlug } from "../../utils/slugify";
+import { getStoryPath } from "../../utils/slugify";
 import X from "../components/icons/X";
 
 const PersonCard = props => {
@@ -15,8 +15,12 @@ const PersonCard = props => {
   const close = () => setShowDialog(false);
 
   // Person might not have story (e.g. person is a teacher).
-  const storySlug = props.story
-    ? getStorySlug(props.story.storyTitle, props.name)
+  const storyPath = props.story
+    ? getStoryPath({
+        slug: props.story.slug,
+        storyTitle: props.story.storyTitle,
+        authorFirstName: props.story.authorFirstName || props.name
+      })
     : undefined;
 
   const image = props.photo?.asset ? getImage(props.photo.asset) : null;
@@ -93,7 +97,7 @@ const PersonCard = props => {
           {props.story && (
             <p className="caption1">
               Story:{" "}
-              <Link to={`/story/${storySlug}`}>{props.story.storyTitle}</Link>
+              <Link to={storyPath}>{props.story.storyTitle}</Link>
             </p>
           )}
         </div>

--- a/web/src/components/StoryCard.tsx
+++ b/web/src/components/StoryCard.tsx
@@ -4,8 +4,12 @@ import { Link, graphql } from "gatsby";
 import { GatsbyImage, getImage } from "gatsby-plugin-image";
 import * as slugUtils from "../../utils/slugify";
 
-const StoryCard = ({ title, photo, author }) => {
-  const slug = slugUtils.getStorySlug(title, author);
+const StoryCard = ({ title, photo, author, slug }) => {
+  const storyPath = slugUtils.getStoryPath({
+    slug,
+    storyTitle: title,
+    authorFirstName: author
+  });
   const image = photo?.asset ? getImage(photo.asset) : null;
 
   return (
@@ -18,7 +22,7 @@ const StoryCard = ({ title, photo, author }) => {
       }}
     >
       <Link
-        to={`/story/${slug}`}
+        to={storyPath}
         sx={{
           textDecoration: "none"
         }}
@@ -85,6 +89,7 @@ export const query = graphql`
     id
     authorFirstName
     storyTitle
+    slug
     photo {
       asset {
         id

--- a/web/src/pages/team.tsx
+++ b/web/src/pages/team.tsx
@@ -85,6 +85,7 @@ export const pageQuery = graphql`
         story {
           authorFirstName
           storyTitle
+          slug
         }
       }
     }

--- a/web/src/templates/tag.tsx
+++ b/web/src/templates/tag.tsx
@@ -20,6 +20,7 @@ const TagPage = ({ pageContext: { nodes, tag, tagType } }) => (
           photo={node.photo}
           title={node.storyTitle}
           author={node.authorFirstName}
+          slug={node.slug}
         />
       ))}
     </Gallery>

--- a/web/src/templates/unfiltered-stories-page.tsx
+++ b/web/src/templates/unfiltered-stories-page.tsx
@@ -57,6 +57,7 @@ const UnfilteredStoriesPage = ({
               author={story.authorFirstName}
               title={story.storyTitle}
               photo={story.photo}
+              slug={story.slug}
             />
           );
         })}

--- a/web/utils/slugify.ts
+++ b/web/utils/slugify.ts
@@ -1,4 +1,4 @@
-function slugify(string) {
+export function slugify(string) {
   const a =
     "àáâäæãåāăąçćčđďèéêëēėęěğǵḧîïíīįìłḿñńǹňôöòóœøōõṕŕřßśšşșťțûüùúūǘůűųẃẍÿýžźż·/_,:;";
   const b =
@@ -17,13 +17,27 @@ function slugify(string) {
     .replace(/-+$/, ""); // Trim - from end of text
 }
 
-export function getStorySlug(storyTitle, authorFirstName) {
+export function getLegacyStorySlug(storyTitle, authorFirstName) {
   const truncatedStoryTitle = storyTitle
     .split(" ")
     .slice(0, 4)
     .join(" ");
   const firstLetterOfName = authorFirstName[0];
   return slugify(`${truncatedStoryTitle}-${firstLetterOfName}`);
+}
+
+export const getStorySlug = getLegacyStorySlug;
+
+export function normalizeStorySlug(slug) {
+  return slug.replace(/^\/+/, "").replace(/^story\//, "").replace(/\/+$/, "");
+}
+
+export function getStoryPath({ slug, storyTitle, authorFirstName }) {
+  const storySlug = slug
+    ? normalizeStorySlug(slug)
+    : getLegacyStorySlug(storyTitle, authorFirstName);
+
+  return `/story/${storySlug}`;
 }
 
 export function getTagSlug(tag) {


### PR DESCRIPTION
## Summary
- Add canonical story URL support using stored Sanity `story.slug` values
- Keep legacy generated story URLs as a fallback until the backfill runs
- Add Gatsby redirects from legacy story paths to canonical paths once slugs exist
- Add a dry-run/write migration script for `/story/{year}/{title-slug}/` slugs with deterministic numeric suffixes for same-year title collisions
- Add Studio validation for the hidden story slug format

## Migration notes
1. Run `npm run story-slugs:audit` and review the summary.
2. Run `npm run story-slugs:audit -- --redirects` and copy reviewed safe redirects into `web/static/_redirects`.
3. Run `SANITY_WRITE_TOKEN=... npm run story-slugs:write` to backfill Sanity `story.slug`.
4. Redeploy the site.

The audit currently finds 1,177 slug updates, 35 stories in same-year title collision groups that receive numeric suffixes, 1,165 safe legacy redirects, and 6 ambiguous legacy redirects that are skipped for manual review.

## Verification
- `npm run story-slugs:audit`
- `NODE_OPTIONS=--openssl-legacy-provider npm --prefix web run build`
- `npm --prefix web run typecheck`
- `npm test`